### PR TITLE
Fix login request to retrieve refresh_token and profile information

### DIFF
--- a/MvpApi.Uwp/Common/Constants.cs
+++ b/MvpApi.Uwp/Common/Constants.cs
@@ -3,7 +3,7 @@
     // IMPORTANT Get your own key here https://mvpapi.portal.azure-api.net/ these keys will be disabled as soon as testing is complete
     public static class Constants
     {
-        public static string Scope = "wl.signin";
+        public static string Scope = "wl.emails%20wl.basic%20wl.offline_access%20wl.signin";
         public static string SubscriptionKey = "3d199a7fb1c443e1985375f0572f58f8";
         public static string ClientId = "090fa1d9-3d6f-4f6f-a733-a8b8a3fe16ff";
         public static string ClientSecret = "JuUCyRquexio3oVjah4jWD7";


### PR DESCRIPTION
To get a refresh_token and profile picture information at login, we need to ask for more Scopes during login request

Fixes #50