### PR TITLE
SDK and Dependency Updates

### DIFF
--- a/MvpApi.Uwp/MvpApi.Uwp.csproj
+++ b/MvpApi.Uwp/MvpApi.Uwp.csproj
@@ -298,7 +298,7 @@
       <Version>5.0.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.0.181018003.1</Version>
+      <Version>2.0.181011001</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>10.0.3</Version>

--- a/MvpApi.Uwp/MvpApi.Uwp.csproj
+++ b/MvpApi.Uwp/MvpApi.Uwp.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>MvpApi.Uwp</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.17134.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/MvpApi.UwpBackgroundTasks/MvpApi.UwpBackgroundTasks.csproj
+++ b/MvpApi.UwpBackgroundTasks/MvpApi.UwpBackgroundTasks.csproj
@@ -11,7 +11,7 @@
     <AssemblyName>MvpApi.UwpBackgroundTasks</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17763.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition=" '$(TargetPlatformVersion)' == '' ">10.0.17134.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 A client application to allow for faster contribution browsing, editing and upload to help renewing MVPs get up to date for renewal.
 ## Build Status
 
-| Platform | Release Branch  |
-|----------|-----------------------|
-| UWP | [![Build status](https://lance.visualstudio.com/MVP%20Companion%20Ops/_apis/build/status/MVP%20Companion%20UWP)](https://lance.visualstudio.com/MVP%20Companion%20Ops/_build/latest?definitionId=5) |
+| Platform | Master | Release |
+|----------|-----------------------|-----------------------|
+| UWP | [![Build status](https://lance.visualstudio.com/MVP%20Companion%20Ops/_apis/build/status/MVP%20Companion%20UWP%20Master)](https://lance.visualstudio.com/MVP%20Companion%20Ops/_build/latest?definitionId=0) |  [![Build status](https://lance.visualstudio.com/MVP%20Companion%20Ops/_apis/build/status/MVP%20Companion%20UWP)](https://lance.visualstudio.com/MVP%20Companion%20Ops/_build/latest?definitionId=5) |
 
 ### Installation
 - [Microsoft Store (Windows 10)](https://www.microsoft.com/store/apps/9NRXNX3WLH77) 


### PR DESCRIPTION
Needed to update the Target SDK to 17134 because the DevOps Hosted VS2017 agent still doesnt have 17763 SDK installed. This has no functional effect on the app, so the drop is okay until DevOps updated the VMs for the agents.