### PR TITLE
Version 1.9.1 Release

### DIFF
--- a/MvpApi.Common/Models/AwardConsiderationAnswerModel.cs
+++ b/MvpApi.Common/Models/AwardConsiderationAnswerModel.cs
@@ -1,0 +1,18 @@
+﻿namespace MvpApi.Common.Models
+{
+    /// <summary>
+    /// Model for the MVP's answers for award consideration questions.
+    /// </summary>
+    public class AwardConsiderationAnswerModel
+    {
+        /// <summary>
+        /// Gets or sets the AwardQuestionId.
+        /// </summary>
+        public string AwardQuestionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Answer.
+        /// </summary>
+        public string Answer { get; set; }
+    }
+}

--- a/MvpApi.Common/Models/AwardConsiderationQuestionModel.cs
+++ b/MvpApi.Common/Models/AwardConsiderationQuestionModel.cs
@@ -1,0 +1,23 @@
+﻿namespace MvpApi.Common.Models
+{
+    /// <summary>
+    /// Model for the MVP award consideration questions.
+    /// </summary>
+    public class AwardConsiderationQuestionModel
+    {
+        /// <summary>
+        /// Gets or sets the AwardQuestionId.
+        /// </summary>
+        public string AwardQuestionId { get; set; }
+
+        /// <summary>
+        /// Gets or sets the Answer.
+        /// </summary>
+        public string QuestionContent { get; set; }
+
+        /// <summary>
+        /// Gets or sets IsRequired. This value determines if the question must be answered.
+        /// </summary>
+        public bool IsRequired { get; set; } = true;
+    }
+}

--- a/MvpApi.Common/Models/QuestionnaireItem.cs
+++ b/MvpApi.Common/Models/QuestionnaireItem.cs
@@ -1,0 +1,31 @@
+﻿using CommonHelpers.Common;
+
+namespace MvpApi.Common.Models
+{
+    /// <summary>
+    /// A model to hold both the Award Consideration question and answer for rendering in the UI form
+    /// </summary>
+    public class QuestionnaireItem : BindableBase
+    {
+        private AwardConsiderationQuestionModel _questionItem;
+        private AwardConsiderationAnswerModel _answerItem;
+
+        /// <summary>
+        /// Gets or sets the Question object.
+        /// </summary>
+        public AwardConsiderationQuestionModel QuestionItem
+        {
+            get => _questionItem;
+            set => SetProperty(ref _questionItem, value);
+        }
+
+        /// <summary>
+        /// Gets or sets the Answer object.
+        /// </summary>
+        public AwardConsiderationAnswerModel AnswerItem
+        {
+            get => _answerItem;
+            set => SetProperty(ref _answerItem, value);
+        }
+    }
+}

--- a/MvpApi.Services/Apis/MvpApiService.cs
+++ b/MvpApi.Services/Apis/MvpApiService.cs
@@ -69,7 +69,8 @@ namespace MvpApi.Services.Apis
                     }
                     else if (response.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the request for profile information.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        var message = await response.Content.ReadAsStringAsync();
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                     }
                 }
             }
@@ -134,7 +135,8 @@ namespace MvpApi.Services.Apis
                         }
                         else if (response.StatusCode == HttpStatusCode.BadRequest)
                         {
-                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the request for profile photo data.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                            var message = await response.Content.ReadAsStringAsync();
+                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                         }
                     }
                 }
@@ -217,7 +219,8 @@ namespace MvpApi.Services.Apis
                         }
                         else if (response.StatusCode == HttpStatusCode.BadRequest)
                         {
-                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the request for profile photo data.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                            var message = await response.Content.ReadAsStringAsync();
+                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                         }
                     }
                 }
@@ -269,7 +272,8 @@ namespace MvpApi.Services.Apis
                     }
                     else if (response.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the request to get Contributions.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        var message = await response.Content.ReadAsStringAsync();
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                     }
                 }
             }
@@ -327,7 +331,8 @@ namespace MvpApi.Services.Apis
                         }
                         else if (response.StatusCode == HttpStatusCode.BadRequest)
                         {
-                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the format of the Contribution information.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                            var message = await response.Content.ReadAsStringAsync();
+                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                         }
                     }
                 }
@@ -385,7 +390,8 @@ namespace MvpApi.Services.Apis
                         }
                         else if (response.StatusCode == HttpStatusCode.BadRequest)
                         {
-                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the format of the Contribution information.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                            var message = await response.Content.ReadAsStringAsync();
+                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                         }
                     }
                 }
@@ -437,7 +443,8 @@ namespace MvpApi.Services.Apis
                     }
                     else if (response.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the delete request.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        var message = await response.Content.ReadAsStringAsync();
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                     }
                 }
             }
@@ -486,7 +493,8 @@ namespace MvpApi.Services.Apis
                     }
                     else if (response.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - If this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        var message = await response.Content.ReadAsStringAsync();
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                     }
                 }
             }
@@ -533,7 +541,8 @@ namespace MvpApi.Services.Apis
                     }
                     else if (response.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - If this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        var message = await response.Content.ReadAsStringAsync();
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                     }
                 }
             }
@@ -624,7 +633,8 @@ namespace MvpApi.Services.Apis
                     }
                     else if (response.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - If this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        var message = await response.Content.ReadAsStringAsync();
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                     }
                 }
             }
@@ -681,7 +691,8 @@ namespace MvpApi.Services.Apis
                         }
                         else if (response.StatusCode == HttpStatusCode.BadRequest)
                         {
-                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - Something was wrong with the OnlineIdentity data and it was not accepted by the server.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                            var message = await response.Content.ReadAsStringAsync();
+                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                         }
                     }
                 }
@@ -727,7 +738,8 @@ namespace MvpApi.Services.Apis
                     }
                     else if (response.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the format of the uploaded data.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        var message = await response.Content.ReadAsStringAsync();
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                     }
                 }
             }
@@ -774,7 +786,8 @@ namespace MvpApi.Services.Apis
                     }
                     else if (response.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - If this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        var message = await response.Content.ReadAsStringAsync();
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                     }
                 }
             }
@@ -820,7 +833,8 @@ namespace MvpApi.Services.Apis
                     }
                     else if (response.StatusCode == HttpStatusCode.BadRequest)
                     {
-                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - If this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        var message = await response.Content.ReadAsStringAsync();
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                     }
                 }
             }
@@ -880,7 +894,8 @@ namespace MvpApi.Services.Apis
                         }
                         else if (response.StatusCode == HttpStatusCode.BadRequest)
                         {
-                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the format of the Contribution information.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                            var message = await response.Content.ReadAsStringAsync();
+                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                         }
                     }
                 }
@@ -934,7 +949,8 @@ namespace MvpApi.Services.Apis
                         }
                         else if (response.StatusCode == HttpStatusCode.BadRequest)
                         {
-                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the format of the Contribution information.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                            var message = await response.Content.ReadAsStringAsync();
+                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = message });
                         }
                     }
                 }
@@ -945,7 +961,7 @@ namespace MvpApi.Services.Apis
 
                 if (e.Message.Contains("500"))
                 {
-                    RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsServerError = true });
+                    RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsServerError = true, Message = e.Message});
                 }
 
                 Debug.WriteLine($"SubmitContributionAsync HttpRequestException: {e}");

--- a/MvpApi.Services/Apis/MvpApiService.cs
+++ b/MvpApi.Services/Apis/MvpApiService.cs
@@ -29,7 +29,7 @@ namespace MvpApi.Services.Apis
                 handler.AutomaticDecompression = DecompressionMethods.Deflate | DecompressionMethods.GZip;
 
             _client = new HttpClient(handler);
-            _client.BaseAddress = new Uri("https://mvpapi.azure-api.net/api/");
+            _client.BaseAddress = new Uri("https://mvpapi.azure-api.net/mvp/api/");
             _client.DefaultRequestHeaders.Add("Ocp-Apim-Subscription-Key", "3d199a7fb1c443e1985375f0572f58f8");
             _client.DefaultRequestHeaders.Add("Authorization", authorizationHeaderContent);
         }

--- a/MvpApi.Services/Apis/MvpApiService.cs
+++ b/MvpApi.Services/Apis/MvpApiService.cs
@@ -313,7 +313,7 @@ namespace MvpApi.Services.Apis
                 {
                     content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
-                    using (var response = await _client.PostAsync("contributions", content))
+                    using (var response = await _client.PostAsync("contributions?", content))
                     {
                         if (response.IsSuccessStatusCode)
                         {
@@ -372,7 +372,7 @@ namespace MvpApi.Services.Apis
                 {
                     content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
 
-                    using (var response = await _client.PutAsync("contributions", content))
+                    using (var response = await _client.PutAsync("contributions?", content))
                     {
                         if (response.IsSuccessStatusCode)
                         {
@@ -647,8 +647,7 @@ namespace MvpApi.Services.Apis
 
             return null;
         }
-
-        // TODO MVP API recently added support for submitting a new Online Identity, will be added in 1.9.1 or later
+        
         public async Task<OnlineIdentity> SubmitOnlineIdentityAsync(OnlineIdentityViewModel onlineIdentity)
         {
             if (onlineIdentity == null)
@@ -748,6 +747,213 @@ namespace MvpApi.Services.Apis
                 await e.LogExceptionAsync();
 
                 Debug.WriteLine($"SubmitOnlineIdentitiesAsync Exception: {e}");
+            }
+
+            return false;
+        }
+        
+        /// <summary>
+        /// Gets the current Award Consideration Questions list.
+        /// </summary>
+        /// <returns>The list of questions to be answered for consideration in the next award period.</returns>
+        public async Task<IReadOnlyList<AwardConsiderationQuestionModel>> GetAwardConsiderationQuestionsAsync()
+        {
+            try
+            {
+                using (var response = await _client.GetAsync("awardconsideration/getcurrentquestions"))
+                {
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var json = await response.Content.ReadAsStringAsync();
+                        return JsonConvert.DeserializeObject<IReadOnlyList<AwardConsiderationQuestionModel>>(json);
+                    }
+
+                    if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+                    {
+                        AccessTokenExpired?.Invoke(this, new ApiServiceEventArgs { IsTokenRefreshNeeded = true });
+                    }
+                    else if (response.StatusCode == HttpStatusCode.BadRequest)
+                    {
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - If this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                    }
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                await e.LogExceptionAsync();
+
+                if (e.Message.Contains("500"))
+                {
+                    RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsServerError = true });
+                }
+
+                Debug.WriteLine($"GetOnlineIdentitiesAsync HttpRequestException: {e}");
+            }
+            catch (Exception e)
+            {
+                await e.LogExceptionAsync();
+                Debug.WriteLine($"GetOnlineIdentitiesAsync Exception: {e}");
+            }
+
+            return null;
+        }
+        
+        /// <summary>
+        /// Gets the MVP's currently saved answers for the Award consideration questions
+        /// </summary>
+        /// <returns>The list of questions to be answered for consideration in the next award period.</returns>
+        public async Task<IReadOnlyList<AwardConsiderationAnswerModel>> GetAwardConsiderationAnswersAsync()
+        {
+            try
+            {
+                using (var response = await _client.GetAsync("awardconsideration/GetAnswers"))
+                {
+                    if (response.IsSuccessStatusCode)
+                    {
+                        var json = await response.Content.ReadAsStringAsync();
+                        return JsonConvert.DeserializeObject<IReadOnlyList<AwardConsiderationAnswerModel>>(json);
+                    }
+
+                    if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+                    {
+                        AccessTokenExpired?.Invoke(this, new ApiServiceEventArgs { IsTokenRefreshNeeded = true });
+                    }
+                    else if (response.StatusCode == HttpStatusCode.BadRequest)
+                    {
+                        RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - If this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                    }
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                await e.LogExceptionAsync();
+
+                if (e.Message.Contains("500"))
+                {
+                    RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsServerError = true });
+                }
+
+                Debug.WriteLine($"GetOnlineIdentitiesAsync HttpRequestException: {e}");
+            }
+            catch (Exception e)
+            {
+                await e.LogExceptionAsync();
+                Debug.WriteLine($"GetOnlineIdentitiesAsync Exception: {e}");
+            }
+
+            return null;
+        }
+
+        /// <summary>
+        /// Saves the MVP's answers to the Aware Consideration questions.
+        /// IMPORTANT NOTE:
+        /// This does NOT submit them for review by the MVP award team, it is intended to be used to save the answers.
+        /// To submit the questions, call SubmitAwardConsiderationAnswerAsync after saving the answers.
+        /// </summary>
+        /// <param name="answers"></param>
+        /// <returns></returns>
+        public async Task<List<AwardConsiderationAnswerModel>> SaveAwardConsiderationAnswerAsync(IEnumerable<AwardConsiderationAnswerModel> answers)
+        {
+            if (answers == null)
+                throw new NullReferenceException("The contribution parameter was null.");
+
+            try
+            {
+                var serializedContribution = JsonConvert.SerializeObject(answers);
+                byte[] byteData = Encoding.UTF8.GetBytes(serializedContribution);
+
+                using (var content = new ByteArrayContent(byteData))
+                {
+                    content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+                    using (var response = await _client.PostAsync("awardconsideration/saveanswers?", content))
+                    {
+                        if (response.IsSuccessStatusCode)
+                        {
+                            var json = await response.Content.ReadAsStringAsync();
+                            return JsonConvert.DeserializeObject<List<AwardConsiderationAnswerModel>>(json);
+                        }
+
+                        if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+                        {
+                            AccessTokenExpired?.Invoke(this, new ApiServiceEventArgs { IsTokenRefreshNeeded = true });
+                        }
+                        else if (response.StatusCode == HttpStatusCode.BadRequest)
+                        {
+                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the format of the Contribution information.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        }
+                    }
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                await e.LogExceptionAsync();
+
+                if (e.Message.Contains("500"))
+                {
+                    RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsServerError = true });
+                }
+
+                Debug.WriteLine($"SubmitContributionAsync HttpRequestException: {e}");
+            }
+            catch (Exception e)
+            {
+                await e.LogExceptionAsync();
+                Debug.WriteLine($"SubmitContributionAsync Exception: {e}");
+            }
+
+            return null;
+        }
+        
+        /// <summary>
+        /// Submits the MVP's answers for award consideration questions.
+        /// WARNING - THIS CAN ONLY BE DONE ONCE PER AWARD PERIOD, THE ANSWERS CANNOT BE CHANGED AFTER SUBMISSION.
+        /// </summary>
+        /// <returns>If the submission was successful</returns>
+        public async Task<bool> SubmitAwardConsiderationAnswerAsync()
+        {
+            try
+            {
+                var serializedContribution = JsonConvert.SerializeObject(string.Empty);
+                byte[] byteData = Encoding.UTF8.GetBytes(serializedContribution);
+
+                using (var content = new ByteArrayContent(byteData))
+                {
+                    content.Headers.ContentType = new MediaTypeHeaderValue("application/json");
+
+                    using (var response = await _client.PostAsync("awardconsideration/SubmitAnswers?", content))
+                    {
+                        if (response.IsSuccessStatusCode)
+                        {
+                            return true;
+                        }
+
+                        if (response.StatusCode == HttpStatusCode.Unauthorized || response.StatusCode == HttpStatusCode.Forbidden)
+                        {
+                            AccessTokenExpired?.Invoke(this, new ApiServiceEventArgs { IsTokenRefreshNeeded = true });
+                        }
+                        else if (response.StatusCode == HttpStatusCode.BadRequest)
+                        {
+                            RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsBadRequest = true, Message = "Bad Request Error - The API service didn't accept the format of the Contribution information.\n\nIf this continues to happen, please open a GitHub issue so we can fix this immediately (go to the About page for a direct link)." });
+                        }
+                    }
+                }
+            }
+            catch (HttpRequestException e)
+            {
+                await e.LogExceptionAsync();
+
+                if (e.Message.Contains("500"))
+                {
+                    RequestErrorOccurred?.Invoke(this, new ApiServiceEventArgs { IsServerError = true });
+                }
+
+                Debug.WriteLine($"SubmitContributionAsync HttpRequestException: {e}");
+            }
+            catch (Exception e)
+            {
+                await e.LogExceptionAsync();
+                Debug.WriteLine($"SubmitContributionAsync Exception: {e}");
             }
 
             return false;

--- a/MvpApi.Uwp/Dialogs/AwardQuestionsDialog.xaml
+++ b/MvpApi.Uwp/Dialogs/AwardQuestionsDialog.xaml
@@ -19,7 +19,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
 
-        <ListView x:Name="ItemsListView" 
+        <ListView x:Name="ItemsListView"
                   SelectionMode="None">
             <ListView.ItemTemplate>
                 <DataTemplate>
@@ -55,10 +55,10 @@
         </ListView>
 
         <Grid HorizontalAlignment="Center"
-                    Padding="10"
-                    Background="WhiteSmoke"
-                    Margin="0,0,0,20"
-                    Grid.Row="1">
+              Padding="10"
+              Background="WhiteSmoke"
+              Margin="0,0,0,20"
+              Grid.Row="1">
             <Grid.RowDefinitions>
                 <RowDefinition Height="Auto" />
                 <RowDefinition Height="Auto" />
@@ -71,6 +71,8 @@
                     Foreground="White"
                     Click="SubmitButton_Clicked"
                     HorizontalAlignment="Center" />
+
+
             <CheckBox x:Name="ConfirmationCheckBox"
                       Checked="ConfirmationCheckBox_OnChecked"
                       Unchecked="ConfirmationCheckBox_OnUnchecked"
@@ -78,6 +80,16 @@
                       Content="Enable Submission (answers are not editable after submission!)."
                       Margin="0,10,0,0"
                       Grid.Row="1" />
+
+            <Grid Background="#99000000"
+                  Grid.RowSpan="2">
+                <TextBlock Text="Due to the permanence of submitting answers, only 'Save Answers' is enabled during the beta. You can submit your saved answers on the MVP portal."
+                           TextWrapping="WrapWholeWords"
+                           HorizontalTextAlignment="Center"
+                           Foreground="White"
+                           VerticalAlignment="Center"
+                           Margin="20" />
+            </Grid>
         </Grid>
 
         <Grid x:Name="LoadingGrid"

--- a/MvpApi.Uwp/Dialogs/AwardQuestionsDialog.xaml
+++ b/MvpApi.Uwp/Dialogs/AwardQuestionsDialog.xaml
@@ -1,0 +1,100 @@
+﻿<ContentDialog x:Class="MvpApi.Uwp.Dialogs.AwardQuestionsDialog"
+               xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+               xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+               xmlns:local="using:MvpApi.Uwp.Dialogs"
+               xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+               xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+               xmlns:primitives="using:Telerik.UI.Xaml.Controls.Primitives"
+               mc:Ignorable="d"
+               Title="MVP Award Questionnaire (BETA)"
+               PrimaryButtonText="Save Answers"
+               SecondaryButtonText="Cancel"
+               PrimaryButtonClick="SaveAnswersButton_Click"
+               SecondaryButtonClick="CancelButton_Click">
+
+    <Grid MinWidth="400"
+          MinHeight="600">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+        </Grid.RowDefinitions>
+
+        <ListView x:Name="ItemsListView" 
+                  SelectionMode="None">
+            <ListView.ItemTemplate>
+                <DataTemplate>
+                    <primitives:RadExpanderControl>
+                        <primitives:RadExpanderControl.Content>
+                            <Grid DataContext="{Binding QuestionItem}">
+                                <TextBlock Text="{Binding QuestionContent}"
+                                           TextWrapping="WrapWholeWords" />
+                            </Grid>
+                        </primitives:RadExpanderControl.Content>
+                        <primitives:RadExpanderControl.ExpandableContent>
+                            <Grid DataContext="{Binding AnswerItem}"
+                                  Margin="0,0,0,10">
+                                <TextBox Text="{Binding Answer, Mode=TwoWay}"
+                                         MinHeight="200" />
+                            </Grid>
+                        </primitives:RadExpanderControl.ExpandableContent>
+                    </primitives:RadExpanderControl>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+            <ListView.ItemContainerStyle>
+                <Style TargetType="ListViewItem">
+                    <Setter Property="HorizontalContentAlignment"
+                            Value="Stretch" />
+                    <Setter Property="HorizontalAlignment"
+                            Value="Stretch" />
+                    <Setter Property="VerticalContentAlignment"
+                            Value="Stretch" />
+                    <Setter Property="VerticalAlignment"
+                            Value="Stretch" />
+                </Style>
+            </ListView.ItemContainerStyle>
+        </ListView>
+
+        <Grid HorizontalAlignment="Center"
+                    Padding="10"
+                    Background="WhiteSmoke"
+                    Margin="0,0,0,20"
+                    Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+
+            <Button x:Name="SubmitButton"
+                    Content="Submit Answers"
+                    IsEnabled="False"
+                    Background="Green"
+                    Foreground="White"
+                    Click="SubmitButton_Clicked"
+                    HorizontalAlignment="Center" />
+            <CheckBox x:Name="ConfirmationCheckBox"
+                      Checked="ConfirmationCheckBox_OnChecked"
+                      Unchecked="ConfirmationCheckBox_OnUnchecked"
+                      HorizontalAlignment="Center"
+                      Content="Enable Submission (answers are not editable after submission!)."
+                      Margin="0,10,0,0"
+                      Grid.Row="1" />
+        </Grid>
+
+        <Grid x:Name="LoadingGrid"
+              Visibility="Collapsed"
+              Background="#DDFFFFFF"
+              Grid.RowSpan="2">
+
+            <StackPanel VerticalAlignment="Center">
+                <ProgressBar x:Name="StatusProgressBar"
+                             IsIndeterminate="True"
+                             VerticalAlignment="Center" />
+                <TextBlock x:Name="StatusTextBlock"
+                           Style="{ThemeResource SubtitleTextBlockStyle}"
+                           TextAlignment="Center"
+                           TextWrapping="WrapWholeWords"
+                           Text="Loading..." />
+            </StackPanel>
+        </Grid>
+    </Grid>
+</ContentDialog>

--- a/MvpApi.Uwp/Dialogs/AwardQuestionsDialog.xaml.cs
+++ b/MvpApi.Uwp/Dialogs/AwardQuestionsDialog.xaml.cs
@@ -1,0 +1,176 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Windows.ApplicationModel;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using CommonHelpers.Common;
+using MvpApi.Common.Models;
+using Template10.Utils;
+
+namespace MvpApi.Uwp.Dialogs
+{
+    public sealed partial class AwardQuestionsDialog : ContentDialog
+    {
+        private ObservableCollection<QuestionnaireItem> Items { get; set; } = new ObservableCollection<QuestionnaireItem>();
+
+        public AwardQuestionsDialog()
+        {
+            this.InitializeComponent();
+            
+
+            if (DesignMode.DesignModeEnabled || DesignMode.DesignMode2Enabled)
+            {
+                ItemsListView.ItemsSource = MvpApi.Uwp.Helpers.DesignTimeHelpers.GenerateQuestionnaireItems();
+            }
+            else
+            {
+                ItemsListView.ItemsSource = Items;
+            }
+
+            Loaded += AwardQuestionsDialog_Loaded;
+        }
+
+        private async void AwardQuestionsDialog_Loaded(object sender, RoutedEventArgs e)
+        {
+            ShowProgress("getting questions...");
+
+            // Go through the questions and populate the ListView.
+
+            var questions = new List<AwardConsiderationQuestionModel>(await App.ApiService.GetAwardConsiderationQuestionsAsync());
+
+            foreach (var question in questions)
+            {
+                Items.Add(new QuestionnaireItem { QuestionItem = question });
+            }
+
+            // Check for saved answers an update the matching questions.
+
+            ShowProgress("getting saved answers...");
+
+            var savedAnswers = await App.ApiService.GetAwardConsiderationAnswersAsync();
+
+            var answers = new List<AwardConsiderationAnswerModel>();
+            
+            // If there is a 400 error, this means the MVP has already submitted their answers.
+            if (savedAnswers == null)
+            {
+                ShowProgress("You've likely already submitted your answers. If not, try again later.");
+
+                Items.ForEach(item=>item.AnswerItem = new AwardConsiderationAnswerModel());
+
+                SubmitButton.IsEnabled = false;
+                ConfirmationCheckBox.IsEnabled = false;
+                IsPrimaryButtonEnabled = false;
+            }
+            else
+            {
+                // Go through the questions and see if there is already an Answer for it.
+                foreach (var item in Items)
+                {
+                    var matchingAnswer = answers.FirstOrDefault(a => a.AwardQuestionId == item.QuestionItem.AwardQuestionId);
+
+                    if (matchingAnswer != null)
+                    {
+                        // If there is a preexisting answer, set it
+                        item.AnswerItem = matchingAnswer;
+                    }
+                }
+            }
+            
+            HideProgress();
+        }
+
+        private async void SaveAnswersButton_Click(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+            var deferral = args.GetDeferral();
+
+            try
+            {
+                var answers = new List<AwardConsiderationAnswerModel>();
+
+                if (answers.Count == 0)
+                    return;
+
+                foreach (var item in Items)
+                {
+                    answers.Add(item.AnswerItem);
+                }
+
+                await App.ApiService.SaveAwardConsiderationAnswerAsync(answers);
+            }
+            finally
+            {
+                deferral.Complete();
+
+            }
+
+            this.Hide();
+        }
+
+        private void CancelButton_Click(ContentDialog sender, ContentDialogButtonClickEventArgs args)
+        {
+            this.Hide();
+        }
+
+        private async void SubmitButton_Clicked(object sender, RoutedEventArgs e)
+        {
+            // Need to get double confirmation from user, this is not undoable!!!
+            if (ConfirmationCheckBox.IsChecked == true)
+            {
+                ShowProgress("submitting answers...");
+
+                var result = true; //await App.ApiService.SubmitAwardConsiderationAnswerAsync();
+                
+                if (result)
+                {
+                    SubmitButton.Content = "success";
+                    SubmitButton.IsEnabled = false;
+                    ConfirmationCheckBox.IsEnabled = false;
+                }
+
+                HideProgress();
+            }
+        }
+
+        private void ShowProgress(string text)
+        {
+            if(LoadingGrid.Visibility != Visibility.Visible)
+            {
+                LoadingGrid.Visibility = Visibility.Visible;
+            }
+
+            if (!StatusProgressBar.IsIndeterminate)
+            {
+                StatusProgressBar.IsIndeterminate = true;
+            }
+
+            StatusTextBlock.Text = text;
+        }
+
+        private void HideProgress()
+        {
+            if (LoadingGrid.Visibility != Visibility.Collapsed)
+            {
+                LoadingGrid.Visibility = Visibility.Collapsed;
+            }
+
+            if (StatusProgressBar.IsIndeterminate)
+            {
+                StatusProgressBar.IsIndeterminate = false;
+            }
+
+            StatusTextBlock.Text = string.Empty;
+        }
+
+        private void ConfirmationCheckBox_OnChecked(object sender, RoutedEventArgs e)
+        {
+            SubmitButton.IsEnabled = true;
+        }
+
+        private void ConfirmationCheckBox_OnUnchecked(object sender, RoutedEventArgs e)
+        {
+            SubmitButton.IsEnabled = false;
+        }
+    }
+}

--- a/MvpApi.Uwp/Dialogs/AwardQuestionsDialog.xaml.cs
+++ b/MvpApi.Uwp/Dialogs/AwardQuestionsDialog.xaml.cs
@@ -18,15 +18,12 @@ namespace MvpApi.Uwp.Dialogs
         {
             this.InitializeComponent();
             
-
             if (DesignMode.DesignModeEnabled || DesignMode.DesignMode2Enabled)
             {
-                ItemsListView.ItemsSource = MvpApi.Uwp.Helpers.DesignTimeHelpers.GenerateQuestionnaireItems();
+                Items = MvpApi.Uwp.Helpers.DesignTimeHelpers.GenerateQuestionnaireItems();
             }
-            else
-            {
-                ItemsListView.ItemsSource = Items;
-            }
+
+            ItemsListView.ItemsSource = Items;
 
             Loaded += AwardQuestionsDialog_Loaded;
         }

--- a/MvpApi.Uwp/Helpers/DesignTimeHelpers.cs
+++ b/MvpApi.Uwp/Helpers/DesignTimeHelpers.cs
@@ -582,5 +582,68 @@ namespace MvpApi.Uwp.Helpers
                 Submitted = false
             }
         };
+
+        public static ObservableCollection<QuestionnaireItem> GenerateQuestionnaireItems()
+        {
+            var items = new ObservableCollection<QuestionnaireItem>();
+
+            items.Add(new QuestionnaireItem
+            {
+                QuestionItem = new AwardConsiderationQuestionModel
+                {
+                    AwardQuestionId = "13062caa-6a7b-47a9-b58f-2b6a85b2c123",
+                    IsRequired = true,
+                    QuestionContent = "What does it mean to be an MVP for you?"
+                },
+                AnswerItem = new AwardConsiderationAnswerModel
+                {
+                    AwardQuestionId = "13062caa-6a7b-47a9-b58f-2b6a85b2c123"
+                }
+            });
+
+            items.Add(new QuestionnaireItem
+            {
+                QuestionItem = new AwardConsiderationQuestionModel
+                {
+                    AwardQuestionId = "13062caa-6a7b-47a9-b58f-2b6a85b2c234",
+                    IsRequired = true,
+                    QuestionContent = "What do you plan on doing for the next year as a the go-to source for helping the developer community?"
+                },
+                AnswerItem = new AwardConsiderationAnswerModel
+                {
+                    AwardQuestionId = "13062caa-6a7b-47a9-b58f-2b6a85b2c234"
+                }
+            });
+
+            items.Add(new QuestionnaireItem
+            {
+                QuestionItem = new AwardConsiderationQuestionModel
+                {
+                    AwardQuestionId = "13062caa-6a7b-47a9-b58f-2b6a85b2c345",
+                    IsRequired = true,
+                    QuestionContent = "How can the MVP program help better enable you to prive the best support possible?"
+                },
+                AnswerItem = new AwardConsiderationAnswerModel
+                {
+                    AwardQuestionId = "13062caa-6a7b-47a9-b58f-2b6a85b2c345"
+                }
+            });
+
+            items.Add(new QuestionnaireItem
+            {
+                QuestionItem = new AwardConsiderationQuestionModel
+                {
+                    AwardQuestionId = "13062caa-6a7b-47a9-b58f-2b6a85b2c456",
+                    IsRequired = true,
+                    QuestionContent = "Whatcha gonna do, whatcha gonna do, whatcha gonna do when they come for you?"
+                },
+                AnswerItem = new AwardConsiderationAnswerModel
+                {
+                    AwardQuestionId = "13062caa-6a7b-47a9-b58f-2b6a85b2c456"
+                }
+            });
+
+            return items;
+        }
     }
 }

--- a/MvpApi.Uwp/MvpApi.Uwp.csproj
+++ b/MvpApi.Uwp/MvpApi.Uwp.csproj
@@ -119,6 +119,9 @@
     <Compile Include="Dialogs\AdditionalTechnologyAreasPicker.xaml.cs">
       <DependentUpon>AdditionalTechnologyAreasPicker.xaml</DependentUpon>
     </Compile>
+    <Compile Include="Dialogs\AwardQuestionsDialog.xaml.cs">
+      <DependentUpon>AwardQuestionsDialog.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Dialogs\TutorialDialog.xaml.cs">
       <DependentUpon>TutorialDialog.xaml</DependentUpon>
     </Compile>
@@ -233,6 +236,10 @@
       <SubType>Designer</SubType>
     </ApplicationDefinition>
     <Page Include="Dialogs\AdditionalTechnologyAreasPicker.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
+    <Page Include="Dialogs\AwardQuestionsDialog.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>

--- a/MvpApi.Uwp/Package.appxmanifest
+++ b/MvpApi.Uwp/Package.appxmanifest
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Package xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10" xmlns:mp="http://schemas.microsoft.com/appx/2014/phone/manifest" xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10" IgnorableNamespaces="uap mp">
-  <Identity Name="61469LanceLotSoftware.MVPCompanion" Publisher="CN=51B5A8B2-5D86-4826-BBE2-C92E963A4C02" Version="1.9.0.0" />
+  <Identity Name="61469LanceLotSoftware.MVPCompanion" Publisher="CN=51B5A8B2-5D86-4826-BBE2-C92E963A4C02" Version="1.9.1.0" />
   <mp:PhoneIdentity PhoneProductId="22fbf170-42f6-4410-a6a7-189807341e16" PhonePublisherId="00000000-0000-0000-0000-000000000000" />
   <Properties>
     <DisplayName>MVP Companion</DisplayName>

--- a/MvpApi.Uwp/ViewModels/ContributionDetailViewModel.cs
+++ b/MvpApi.Uwp/ViewModels/ContributionDetailViewModel.cs
@@ -195,14 +195,6 @@ namespace MvpApi.Uwp.ViewModels
         
         public async void UploadContributionButton_Click(object sender, RoutedEventArgs e)
         {
-            // TODO Remove temporary navigation blocker
-            await new MessageDialog(
-                    "The MVP API has made breaking changes and the app cannot make any edits or add new contributions at this time. " +
-                    "\n\nI expect to release an update within a day or two with a fix, thank you for your patience - Lance", "Temporarily Disabled")
-                .ShowAsync();
-
-            return;
-
             var isValid = await SelectedContribution.Validate(true);
 
             if (!isValid)

--- a/MvpApi.Uwp/ViewModels/HomePageViewModel.cs
+++ b/MvpApi.Uwp/ViewModels/HomePageViewModel.cs
@@ -119,13 +119,7 @@ namespace MvpApi.Uwp.ViewModels
         
         public async void AddActivityButton_Click(object sender, RoutedEventArgs e)
         {
-            // TODO Remove temporary navigation blocker
-            await new MessageDialog(
-                    "The MVP API has made breaking changes and the app cannot make any edits or add new contributions at this time. " +
-                    "\n\nI expect to release an update within a day or two with a fix, thank you for your patience - Lance", "Temporarily Disabled")
-                .ShowAsync();
-
-            //await BootStrapper.Current.NavigationService.NavigateAsync(typeof(AddContributionsPage));
+            await BootStrapper.Current.NavigationService.NavigateAsync(typeof(AddContributionsPage));
         }
 
         public void ClearSelectionButton_Click(object sender, RoutedEventArgs e)

--- a/MvpApi.Uwp/ViewModels/ProfilePageViewModel.cs
+++ b/MvpApi.Uwp/ViewModels/ProfilePageViewModel.cs
@@ -12,6 +12,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Navigation;
 using MvpApi.Common.Models;
+using MvpApi.Uwp.Dialogs;
 using MvpApi.Uwp.Helpers;
 using MvpApi.Uwp.Views;
 
@@ -140,6 +141,11 @@ namespace MvpApi.Uwp.ViewModels
         public async void RefreshOnlineIdentitiesButton_Click(object sender, RoutedEventArgs e)
         {
             await RefreshOnlineIdentitiesAsync();
+        }
+
+        public async void ShowQuestionnaireButton_Click(object sender, RoutedEventArgs e)
+        {
+            await new AwardQuestionsDialog().ShowAsync();
         }
 
         public async void DeleteOnlineIdentityButton_Click(object sender, RoutedEventArgs e)

--- a/MvpApi.Uwp/ViewModels/ProfilePageViewModel.cs
+++ b/MvpApi.Uwp/ViewModels/ProfilePageViewModel.cs
@@ -15,6 +15,7 @@ using MvpApi.Common.Models;
 using MvpApi.Uwp.Dialogs;
 using MvpApi.Uwp.Helpers;
 using MvpApi.Uwp.Views;
+using Template10.Utils;
 
 namespace MvpApi.Uwp.ViewModels
 {
@@ -54,6 +55,10 @@ namespace MvpApi.Uwp.ViewModels
             get => _selectedOnlineIdentities ?? (_selectedOnlineIdentities = new ObservableCollection<OnlineIdentityViewModel>());
             set => Set(ref _selectedOnlineIdentities, value);
         }
+
+        //public ObservableCollection<VisibilityViewModel> Visibilities { get; } = new ObservableCollection<VisibilityViewModel>();
+
+        //public OnlineIdentityViewModel DraftOnlineIdentity { get; set; } = new OnlineIdentityViewModel();
 
         public string ProfileImagePath
         {
@@ -275,7 +280,16 @@ namespace MvpApi.Uwp.ViewModels
                 this.ProfileImagePath = shellVm.ProfileImagePath;
 
                 await RefreshOnlineIdentitiesAsync();
-                
+
+                //IsBusyMessage = "loading visibility options...";
+
+                //var visibilities = await App.ApiService.GetVisibilitiesAsync();
+
+                //visibilities.ForEach(visibility =>
+                //{
+                //    Visibilities.Add(visibility);
+                //});
+
                 IsBusyMessage = "";
                 IsBusy = false;
             }

--- a/MvpApi.Uwp/Views/ProfilePage.xaml
+++ b/MvpApi.Uwp/Views/ProfilePage.xaml
@@ -186,7 +186,11 @@
             <CommandBar.SecondaryCommands>
                 <AppBarButton Label="Export Online Identities"
                               Click="{x:Bind ViewModel.ExportButton_OnClick}" />
+                <AppBarButton Label="Complete Award Questionnaire"
+                              Icon="OpenWith"
+                              Click="{x:Bind ViewModel.ShowQuestionnaireButton_Click}" />
             </CommandBar.SecondaryCommands>
+            
             <AppBarButton Label="delete identity"
                           Icon="Delete"
                           Visibility="{Binding IsMultipleSelectionEnabled, Converter={StaticResource BoolToVisibilityConverter}}"

--- a/MvpApi.Uwp/Views/ProfilePage.xaml
+++ b/MvpApi.Uwp/Views/ProfilePage.xaml
@@ -175,6 +175,58 @@
                 </ListView.ItemTemplate>
             </ListView>
 
+            <!--<Grid x:Name="OnlineIdentityEditor"
+                  Background="Bisque"
+                  Grid.Row="1"
+                  Grid.Column="1"
+                  Padding="10">
+                <ScrollViewer>
+                    <StackPanel>
+                        <ComboBox Header="Select Social Network"/>
+
+                        <ComboBox ItemsSource="{x:Bind ViewModel.Visibilities}"
+                                  SelectedItem="{Binding DraftOnlineIdentity.OnlineIdentityVisibility, Mode=TwoWay, UpdateSourceTrigger=PropertyChanged}"
+                                  IsTextSearchEnabled="True"
+                                  DisplayMemberPath="Description"
+                                  HorizontalAlignment="Left"
+                                  MinWidth="300"
+                                  Margin="0,10">
+                            <ComboBox.Header>
+                                <StackPanel Orientation="Horizontal">
+                                    <TextBlock Text="Select Visibility"
+                                               Foreground="{ThemeResource ApplicationForegroundThemeBrush}"
+                                               Margin="0,0,5,0" />
+                                    <TextBlock Text="(required)"
+                                               FontStyle="Italic"
+                                               Margin="5,0"
+                                               Foreground="Red" />
+                                </StackPanel>
+                            </ComboBox.Header>
+                        </ComboBox>
+
+                        <StackPanel Orientation="Horizontal">
+                            <Image Source="{Binding DraftOnlineIdentity.SocialNetwork.IconUrl, Converter={StaticResource MvcContentUrlConverter}}"
+                                   Width="20"
+                                   Height="20"
+                                   Margin="0,0,10,0" />
+                            <TextBlock Text="{Binding DraftOnlineIdentity.SocialNetwork.Name}"
+                                       Style="{ThemeResource SubtitleTextBlockStyle}" />
+                        </StackPanel>
+
+                        <TextBlock Text="Social Network"/>
+
+                        <TextBox Header="SocialNetwork.Name" 
+                                 Text="{Binding DraftOnlineIdentity.SocialNetwork.Name}" />
+                        <TextBox Header="SocialNetwork"
+                                 Text="{Binding DraftOnlineIdentity.SocialNetwork.IconUrl}" />
+
+                        <TextBox Text="{Binding DraftOnlineIdentity.Url}" />
+
+                        <TextBox Text="{Binding DraftOnlineIdentity.DisplayName}" />
+                    </StackPanel>
+                </ScrollViewer>
+            </Grid>-->
+
             <primitives:RadBusyIndicator Content="{x:Bind ViewModel.IsBusyMessage, Mode=OneWay}"
                                          IsActive="{x:Bind ViewModel.IsBusy, Mode=OneWay}"
                                          Style="{StaticResource PageBusyIndicatorStyle}"
@@ -186,7 +238,7 @@
             <CommandBar.SecondaryCommands>
                 <AppBarButton Label="Export Online Identities"
                               Click="{x:Bind ViewModel.ExportButton_OnClick}" />
-                <AppBarButton Label="Complete Award Questionnaire"
+                <AppBarButton Label="Complete Award Questionnaire (beta)"
                               Icon="OpenWith"
                               Click="{x:Bind ViewModel.ShowQuestionnaireButton_Click}" />
             </CommandBar.SecondaryCommands>

--- a/MvpApi.Uwp/Views/ShellPage.xaml.cs
+++ b/MvpApi.Uwp/Views/ShellPage.xaml.cs
@@ -309,7 +309,7 @@ namespace MvpApi.Uwp.Views
 
         private async void ApiService_RequestErrorOccurred(object sender, ApiServiceEventArgs e)
         {
-            var message = "Unknown Problem. If this continues to happen, please open a GitHub Issue and we'll investigate further (find the GitHub link on the About page)";
+            var message = "Unknown Server Error";
 
             if (e.IsBadRequest)
             {
@@ -317,8 +317,7 @@ namespace MvpApi.Uwp.Views
             }
             else if (e.IsServerError)
             {
-                message = "There was a 500 (internal server error) making a call to the MVP Api service. This indicates a problem with the API service and is unfortunately outside the control of the app to assist." +
-                    "\r\n\nIf this continues to happen, please open a GitHub Issue and we'll investigate further (find the GitHub link on the About page).";
+                message = e.Message + "\r\n\nIf this continues to happen, please open a GitHub Issue and we'll investigate further (find the GitHub link on the About page).";
             }
             
             await new MessageDialog(message, "MVP API Request Error").ShowAsync();

--- a/MvpApi.UwpBackgroundTasks/UpdateTask.cs
+++ b/MvpApi.UwpBackgroundTasks/UpdateTask.cs
@@ -22,7 +22,7 @@ namespace MvpApi.UwpBackgroundTasks
                             },
                             new AdaptiveText
                             {
-                                Text = "[Important Fix] Addressed a breaking change in the API's endpoints.\r\n[NEW] DataGrid grouping styles and Online Identities."
+                                Text = "Fixed the Fix 😜. The broken MVP API is now unbroken, so we had to 'unfix' the app. Enjoy!"
                             },
                             new AdaptiveImage
                             {


### PR DESCRIPTION
- Reverted changes to fix the broken MVP API controller paths
- Added MVP Award Questions form to edit and submit the new yearly questionnaire (beta - only save is enabled for now)
- Better error surfacing approach. BadRequest errors are delivered directly to the user in order for them to adjust the failed submission. This will help with #75.

Solves #76 and #77. Expected to solve #75 as well (it's related to 77).