### PR TITLE
Enable Dependency Scanning

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,5 +2,21 @@ version: 2
 updates:
   - package-ecosystem: nuget
     directory: "src/MvpApi.Uwp"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: nuget
+    directory: "src/MvpApi.UwpBackgroundTasks"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: nuget
+    directory: "src/MvpApi.Services"
+    open-pull-requests-limit: 5
+    schedule:
+      interval: "weekly"
+  - package-ecosystem: nuget
+    directory: "src/MvpApi.Common"
+    open-pull-requests-limit: 5
     schedule:
       interval: "weekly"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: nuget
+    directory: "src/MvpApi.Uwp"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
Using the new native Dependabot service in Github, enable dependency updates to keep the repo up to date